### PR TITLE
refactor set_fan_mode

### DIFF
--- a/pyecobee/__init__.py
+++ b/pyecobee/__init__.py
@@ -222,12 +222,17 @@ class Ecobee(object):
         log_msg_action = "set fan minimum on time."
         return self.make_request(body, log_msg_action)
 
-    def set_fan_mode(self, index, fan_mode):
+    def set_fan_mode(self, index, fan_mode, cool_temp, heat_temp, hold_type="nextTransition"):
         ''' Set fan mode. Values: auto, minontime, on '''
-        body = ('{"selection":{"selectionType":"thermostats","selectionMatch":'
-                '"' + self.thermostats[index]['identifier'] +
-                '"},"thermostat":{"settings":{"vent":"' + fan_mode +
-                '"}}}')
+        body = {"selection": {
+                    "selectionType": "thermostats",
+                    "selectionMatch": self.thermostats[index]['identifier']},
+                "functions": [{"type": "setHold", "params": {
+                    "holyType": hold_type,
+                    "coolHoldTemp": cool_temp * 10,
+                    "heatHoldTemp": heat_temp * 10,
+                    "fan": fan_mode
+                }}]}
         log_msg_action = "set fan mode"
         return self.make_request(body, log_msg_action)
 


### PR DESCRIPTION
@nkgilley This PR is ready. I made the `body` a `dict` since the `requests` documentation shows it can be passed that way: 

```python
r = requests.post('http://httpbin.org/post', data = {'key':'value'})
```

This way we don't have to worry about double quotes and string concatenation.  If that's okay with you I can push up another PR that changes the remaining requests the same way.  Or if you'd like I can make this PR the way the other request bodies are currently formatted.