### PR TITLE
Fix holdType Typo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 *.iml
+.DS_Store

--- a/pyecobee/__init__.py
+++ b/pyecobee/__init__.py
@@ -234,7 +234,7 @@ class Ecobee(object):
                     "selectionType": "thermostats",
                     "selectionMatch": self.thermostats[index]['identifier']},
                 "functions": [{"type": "setHold", "params": {
-                    "holyType": hold_type,
+                    "holdType": hold_type,
                     "coolHoldTemp": int(cool_temp * 10),
                     "heatHoldTemp": int(heat_temp * 10),
                     "fan": fan_mode
@@ -249,7 +249,7 @@ class Ecobee(object):
                     "selectionType": "thermostats",
                     "selectionMatch": self.thermostats[index]['identifier']},
                 "functions": [{"type": "setHold", "params": {
-                    "holyType": hold_type,
+                    "holdType": hold_type,
                     "coolHoldTemp": int(cool_temp * 10),
                     "heatHoldTemp": int(heat_temp * 10)
                 }}]}
@@ -262,7 +262,7 @@ class Ecobee(object):
                     "selectionType": "thermostats",
                     "selectionMatch": self.thermostats[index]['identifier']},
                 "functions": [{"type": "setHold", "params": {
-                    "holyType": hold_type,
+                    "holdType": hold_type,
                     "holdClimateRef": climate
                 }}]}
         log_msg_action = "set climate hold"


### PR DESCRIPTION
Typo preventings Ecobee from using nextTransition and sets a permanent hold.  Tested with my local Ecobee install and resolved the issue.