### PR TITLE
Pass request body with json parameter and do not re-encode json string

### DIFF
--- a/pyecobee/__init__.py
+++ b/pyecobee/__init__.py
@@ -190,7 +190,7 @@ class Ecobee(object):
                   'Authorization': 'Bearer ' + self.access_token}
         params = {'format': 'json'}
         try:
-            request = requests.post(url, headers=header, params=params, data=json.dumps(body))
+            request = requests.post(url, headers=header, params=params, json=body)
         except RequestException:
             logger.warn("Error connecting to Ecobee.  Possible connectivity outage.")
             return None
@@ -200,7 +200,7 @@ class Ecobee(object):
             logger.info("Error connecting to Ecobee while attempting to %s.  "
                         "Refreshing tokens and trying again.", log_msg_action)
             if self.refresh_tokens():
-                return self.make_request(json.dumps(body), log_msg_action)
+                return self.make_request(body, log_msg_action)
             else:
                 return None
 


### PR DESCRIPTION
On each recursive call of `make_request`, json.dumps is called on body. This results in a string that is already json encoded being re-encoded. Everytime this happens back slashes are escaped again creating invalid requests:
(try: `json.dumps(json.dumps(json.dumps('\\')))` for an example of whats going on).

Requests has specific support for json encoded body by using json= instead of data= when making a post request. This avoids the need to encode and I think is the easiest way to solve this issue.