### PR TITLE
Refresh tokens on 500 status code

### DIFF
--- a/pyecobee/__init__.py
+++ b/pyecobee/__init__.py
@@ -217,7 +217,7 @@ class Ecobee(object):
                 )
         else:
             logger.error(f"Error fetching data from ecobee while attempting to "
-                         f"{log_msg_action}: {request.json()}")
+                         f"{log_msg_action}: {request.status_code}: {request.json()}")
             return None
 
     def set_hvac_mode(self, index, hvac_mode):

--- a/pyecobee/__init__.py
+++ b/pyecobee/__init__.py
@@ -166,12 +166,12 @@ class Ecobee(object):
             self.authenticated = True
             self.thermostats = request.json()['thermostatList']
             return self.thermostats
-        elif request.status_code in [400, 401]:
+        elif request.status_code in [400, 401, 500]:
             self.authenticated = False
             raise ExpiredTokenError("Tokens have expired. Request new tokens from ecobee.")
         else:
-            logger.info("Error connecting to Ecobee while attempting to get "
-                  "thermostat data.  ")
+            logger.error(f"Error connecting to ecobee while attempting to get thermostat data: "
+                         f"{request.status_code}: {request.json()}")
             return None
 
     def get_thermostat(self, index):

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ SOFTWARE.
 """
 
 setup(name='python-ecobee-api',
-      version='0.1.3',
+      version='0.1.4',
       description='Python API for talking to Ecobee thermostats',
       url='https://github.com/nkgilley/python-ecobee-api',
       author='Nolan Gilley',


### PR DESCRIPTION
Testing in Home Assistant has revealed that the ecobee API can also throw a 500 status code when the access token needs refreshing. This PR catches 500, and also improves the error log messages to aid in diagnosing problems in the future.