### PR TITLE
Handle json decode errors

### DIFF
--- a/pyecobee/__init__.py
+++ b/pyecobee/__init__.py
@@ -546,7 +546,7 @@ class Ecobee(object):
                     f"Error from ecobee while attempting to {log_msg_action}: "
                     f"{response.status_code}: {response.json()}"
                 )
-        except RequestException:
+        except (RequestException, json.decoder.JSONDecodeError):
             _LOGGER.error(
                 f"Error connecting to ecobee while attempting to {log_msg_action}. "
                 f"Possible connectivity outage."


### PR DESCRIPTION
A problem discovered downstream in Home Assistant:
```
2020-03-04 21:01:43 ERROR (MainThread) [homeassistant.helpers.entity] Update for climate.upstairs fails
Traceback (most recent call last):
  File "/srv/homeassistant-3.7/lib/python3.7/site-packages/homeassistant/helpers/entity.py", line 279, in async_update_ha_state
    await self.async_device_update()
  File "/srv/homeassistant-3.7/lib/python3.7/site-packages/homeassistant/helpers/entity.py", line 474, in async_device_update
    await self.async_update()
  File "/srv/homeassistant-3.7/lib/python3.7/site-packages/homeassistant/components/ecobee/climate.py", line 289, in async_update
    await self.data.update()
  File "/srv/homeassistant-3.7/lib/python3.7/site-packages/homeassistant/components/ecobee/__init__.py", line 96, in update
    await self._hass.async_add_executor_job(self.ecobee.update)
  File "/usr/lib/python3.7/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/srv/homeassistant-3.7/lib/python3.7/site-packages/pyecobee/__init__.py", line 196, in update
    return self.get_thermostats()
  File "/srv/homeassistant-3.7/lib/python3.7/site-packages/pyecobee/__init__.py", line 177, in get_thermostats
    "GET", ECOBEE_ENDPOINT_THERMOSTAT, log_msg_action, params=params
  File "/srv/homeassistant-3.7/lib/python3.7/site-packages/pyecobee/__init__.py", line 511, in _request
    f"Request response: {response.status_code}: {response.json()}"
  File "/srv/homeassistant-3.7/lib/python3.7/site-packages/requests/models.py", line 889, in json
    self.content.decode(encoding), **kwargs
  File "/usr/lib/python3.7/json/__init__.py", line 348, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python3.7/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python3.7/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```
This will handle a JSON decode error similarly to a `requests` error.