### PR TITLE
Use simplejson if available, similar to requests

### DIFF
--- a/pyecobee/__init__.py
+++ b/pyecobee/__init__.py
@@ -1,9 +1,13 @@
 """ Python Code for Communication with the Ecobee Thermostat """
-import json
 from typing import Optional
 
 import requests
 from requests.exceptions import HTTPError, RequestException
+
+try:
+    import simplejson as json
+except ImportError:
+    import json
 
 from .const import (
     _LOGGER,

--- a/pyecobee/util.py
+++ b/pyecobee/util.py
@@ -1,7 +1,11 @@
 """Utility functions for the python-ecobee-api library."""
-import json
 import os
 from typing import Optional
+
+try:
+    import simplejson as json
+except ImportError:
+    import json
 
 from .const import _LOGGER
 

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ SOFTWARE.
 """
 
 setup(name='python-ecobee-api',
-      version='0.2.2',
+      version='0.2.3',
       description='Python API for talking to Ecobee thermostats',
       url='https://github.com/nkgilley/python-ecobee-api',
       author='Nolan Gilley',


### PR DESCRIPTION
A followup to #47. If an installation has `simplejson` installed, `requests` will prefer that module over the built-in `json`. Unfortunately, this will also change the exception caught in #47 to `simplejson.errors.JSONDecodeError`. This PR imports `json` in the same manner as `requests` so the namespaces line up properly.

Went ahead and bumped the version, too.