### PR TITLE
Improve debug logging

### DIFF
--- a/pyecobee/__init__.py
+++ b/pyecobee/__init__.py
@@ -532,9 +532,15 @@ class Ecobee(object):
             response = requests.request(
                 method, url, headers=headers, params=params, json=body, timeout=ECOBEE_DEFAULT_TIMEOUT
             )
+
+            try:
+                log_msg = response.json()
+            except:
+                log_msg = response.text
             _LOGGER.debug(
-                f"Request response: {response.status_code}: {response.text}"
+                f"Request response: {response.status_code}: {log_msg}"
             )
+            
             response.raise_for_status()
             return response.json()
         except HTTPError:

--- a/pyecobee/__init__.py
+++ b/pyecobee/__init__.py
@@ -114,7 +114,8 @@ class Ecobee(object):
                 f"After authorizing, call request_tokens method."
             )
             return True
-        except (KeyError, TypeError):
+        except (KeyError, TypeError) as err:
+            _LOGGER.debug(f"Error obtaining PIN code from ecobee: {err}")
             return False
 
     def request_tokens(self) -> bool:
@@ -139,8 +140,11 @@ class Ecobee(object):
             self.refresh_token = response["refresh_token"]
             self._write_config()
             self.pin = None
+            _LOGGER.debug(f"Obtained tokens from ecobee: access {self.access_token}, "
+                          f"refresh {self.refresh_token}")
             return True
-        except (KeyError, TypeError):
+        except (KeyError, TypeError) as err:
+            _LOGGER.debug(f"Error obtaining tokens from ecobee: {err}")
             return False
 
     def refresh_tokens(self) -> bool:
@@ -164,8 +168,11 @@ class Ecobee(object):
             self.access_token = response["access_token"]
             self.refresh_token = response["refresh_token"]
             self._write_config()
+            _LOGGER.debug(f"Refreshed tokens from ecobee: access {self.access_token}, "
+                          f"refresh {self.refresh_token}")
             return True
-        except (KeyError, TypeError):
+        except (KeyError, TypeError) as err:
+            _LOGGER.debug(f"Error refreshing tokens from ecobee: {err}")
             return False
 
     def get_thermostats(self) -> bool:

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ SOFTWARE.
 """
 
 setup(name='python-ecobee-api',
-      version='0.2.6',
+      version='0.2.7',
       description='Python API for talking to Ecobee thermostats',
       url='https://github.com/nkgilley/python-ecobee-api',
       author='Nolan Gilley',


### PR DESCRIPTION
I'm trying to track down a problem with tokens becoming invalid when this library is used in Home Assistant, and this PR adds debugging to the PIN and token methods to hopefully pinpoint exactly where the problem arises. Version bumped to next patch version (0.2.7).

(Also: try to debug log the request response in json for easier to parse logs, fall back to text response on any exception.)