### PR TITLE
Fix set climate hold

### DIFF
--- a/pyecobee/__init__.py
+++ b/pyecobee/__init__.py
@@ -337,7 +337,7 @@ class Ecobee(object):
             raise err
 
     def set_climate_hold(
-        self, index: int, climate: str, hold_type: str = "nextTransition"
+        self, index: int, climate: str, hold_type: str = "nextTransition", hold_hours: int = None
     ) -> None:
         """Sets a climate hold (away, home, sleep)."""
         body = {
@@ -348,10 +348,14 @@ class Ecobee(object):
             "functions": [
                 {
                     "type": "setHold",
-                    "params": {"holdType": hold_type, "holdClimateRef": climate},
+                    "params": {"holdType": hold_type, "holdClimateRef": climate, "holdHours": hold_hours},
                 }
             ],
         }
+
+        if hold_type is not "holdHours":
+            del body["functions"][0]["params"]["holdHours"]
+
         log_msg_action = "set climate hold"
 
         try:

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ SOFTWARE.
 """
 
 setup(name='python-ecobee-api',
-      version='0.2.9',
+      version='0.2.10',
       description='Python API for talking to Ecobee thermostats',
       url='https://github.com/nkgilley/python-ecobee-api',
       author='Nolan Gilley',


### PR DESCRIPTION
A change in Home Assistant now requires that we pass the holdHours parameter to set_climate_hold when appropriate. When the holdType is anything other than holdHours, the parameter is omitted.