### PR TITLE
Specify Content-Type and encoding in HTTP header for auth requests

### DIFF
--- a/pyecobee/__init__.py
+++ b/pyecobee/__init__.py
@@ -562,6 +562,10 @@ class Ecobee(object):
                 "Content-Type": "application/json;charset=UTF-8",
                 "Authorization": f"Bearer {self.access_token}",
             }
+        else:
+            headers = {
+                "Content-Type": "application/json;charset=UTF-8",
+            }
 
         _LOGGER.debug(
             f"Making request to {endpoint} endpoint to {log_msg_action}: "


### PR DESCRIPTION
The Ecobee spec indicates that all requests must have the Content-Type and encoding set in the header. This change adds header info for the authorize call. This appeared to be triggering type exceptions in the request call in some conditions.