### PR TITLE
- Update set_fan_mode support for holdHours/coolHoldTemp/heatHoldTemp

### DIFF
--- a/pyecobee/__init__.py
+++ b/pyecobee/__init__.py
@@ -259,25 +259,46 @@ class Ecobee(object):
         cool_temp: int,
         heat_temp: int,
         hold_type: str = "nextTransition",
+        hold_hours: str = "2",
     ) -> None:
         """Sets the fan mode (auto, minontime, on)."""
-        body = {
-            "selection": {
-                "selectionType": "thermostats",
-                "selectionMatch": self.thermostats[index]["identifier"],
-            },
-            "functions": [
-                {
-                    "type": "setHold",
-                    "params": {
-                        "holdType": hold_type,
-                        "coolHoldTemp": int(cool_temp * 10),
-                        "heatHoldTemp": int(heat_temp * 10),
-                        "fan": fan_mode,
-                    },
-                }
-            ],
-        }
+        if hold_type == "holdHours":
+            body = {
+                "selection": {
+                    "selectionType": "thermostats",
+                    "selectionMatch": self.thermostats[index]["identifier"],
+                },
+                "functions": [
+                    {
+                        "type": "setHold",
+                        "params": {
+                            "holdType": hold_type,
+                            "coolHoldTemp": int(cool_temp * 10),
+                            "heatHoldTemp": int(heat_temp * 10),
+                            "fan": fan_mode,
+                            "holdHours": hold_hours,
+                        },
+                    }
+                ],
+            }
+        else:
+            body = {
+                "selection": {
+                    "selectionType": "thermostats",
+                    "selectionMatch": self.thermostats[index]["identifier"],
+                },
+                "functions": [
+                    {
+                        "type": "setHold",
+                        "params": {
+                            "holdType": hold_type,
+                            "coolHoldTemp": int(cool_temp * 10),
+                            "heatHoldTemp": int(heat_temp * 10),
+                            "fan": fan_mode,
+                        },
+                    }
+                ],
+            }
         log_msg_action = "set fan mode"
 
         try:
@@ -353,7 +374,7 @@ class Ecobee(object):
             ],
         }
 
-        if hold_type is not "holdHours":
+        if hold_type != "holdHours":
             del body["functions"][0]["params"]["holdHours"]
 
         log_msg_action = "set climate hold"

--- a/pyecobee/__init__.py
+++ b/pyecobee/__init__.py
@@ -262,43 +262,30 @@ class Ecobee(object):
         hold_hours: str = "2",
     ) -> None:
         """Sets the fan mode (auto, minontime, on)."""
+        body = {
+            "selection": {
+                "selectionType": "thermostats",
+                "selectionMatch": self.thermostats[index]["identifier"],
+            },
+            "functions": [
+                {
+                    "type": "setHold",
+                    "params": {
+                        "holdType": hold_type,
+                        "fan": fan_mode,
+                    },
+                }
+            ],
+        }
+
+        # Set optional parameters in body, only fill in *HoldTemp if they are non-zero
+        if cool_temp != 0:
+            body["functions"][0]["params"]["coolHoldTemp"] = int(cool_temp * 10)
+        if heat_temp != 0:
+            body["functions"][0]["params"]["heatHoldTemp"] = int(heat_temp * 10)
         if hold_type == "holdHours":
-            body = {
-                "selection": {
-                    "selectionType": "thermostats",
-                    "selectionMatch": self.thermostats[index]["identifier"],
-                },
-                "functions": [
-                    {
-                        "type": "setHold",
-                        "params": {
-                            "holdType": hold_type,
-                            "coolHoldTemp": int(cool_temp * 10),
-                            "heatHoldTemp": int(heat_temp * 10),
-                            "fan": fan_mode,
-                            "holdHours": hold_hours,
-                        },
-                    }
-                ],
-            }
-        else:
-            body = {
-                "selection": {
-                    "selectionType": "thermostats",
-                    "selectionMatch": self.thermostats[index]["identifier"],
-                },
-                "functions": [
-                    {
-                        "type": "setHold",
-                        "params": {
-                            "holdType": hold_type,
-                            "coolHoldTemp": int(cool_temp * 10),
-                            "heatHoldTemp": int(heat_temp * 10),
-                            "fan": fan_mode,
-                        },
-                    }
-                ],
-            }
+            body["functions"][0]["params"]["holdHours"] = hold_hours
+
         log_msg_action = "set fan mode"
 
         try:


### PR DESCRIPTION
If holdType is holdHours, setting the fan mode will fail as the Ecobee API requires the holdHours arg to be passed in too. This was causing an error to be returned when setting the fan mode. Modeled change after set_hold_temp.
Also cleaned up an equality check which was throwing warnings.