### PR TITLE
Add additional info to error log when catching RequestException.

### DIFF
--- a/pyecobee/__init__.py
+++ b/pyecobee/__init__.py
@@ -642,9 +642,14 @@ class Ecobee(object):
                 f"Connection to ecobee timed out while attempting to {log_msg_action}. "
                 f"Possible connectivity outage."
             )
-        except (RequestException, json.decoder.JSONDecodeError):
+        except json.decoder.JSONDecodeError:
+            _LOGGER.error(
+                f"Error decoding response from ecobee while attempting to {log_msg_action}. "
+            )
+        except RequestException as err:
             _LOGGER.error(
                 f"Error connecting to ecobee while attempting to {log_msg_action}. "
-                f"Possible connectivity outage."
+                f"Possible connectivity outage.\n"
+                f"{err}"
             )
         return None


### PR DESCRIPTION
RequestException is a catch-all exception thrown from the request()
call. Adding additional exception detail,  for this exception, to error 
logging to help with debugging.

This additional detail would have pointed me at the issue when I was trying to figure out what was failing here #61 

For example, for a DNS issue, the logs would show something like this...
```
2021-03-24 23:45:15 ERROR (SyncWorker_4) [pyecobee] Error connecting to ecobee while attempting to refresh tokens. Possible connectivity outage.
HTTPSConnectionPool(host='apii.ecobee.com', port=443): Max retries exceeded with url: /token?grant_type=refresh_token&refresh_token=BMVJfu1j1YpRxWN39-vm5_0-fAWOIFbf5XTV-6i7_Dbx8&client_id=DSj7G6hVqnwELobA7C9VMxHDqZZRK7I6 (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x10e1a85b0>: Failed to establish a new connection: [Errno 8] nodename nor servname provided, or not known'))
```