### PR TITLE
add a method to set aux heat cutover setting

### DIFF
--- a/pyecobee/__init__.py
+++ b/pyecobee/__init__.py
@@ -675,6 +675,24 @@ class Ecobee(object):
         except (ExpiredTokenError, InvalidTokenError) as err:
             raise err
 
+    def set_aux_cutover_threshold(self, index: int, threshold: int) -> None:
+        """Set the threshold for outdoor temp below which alt heat will be used."""
+        body = {
+            "selection": {
+                "selectionType": "thermostats",
+                "selectionMatch": self.thermostats[index]["identifier"],
+            },
+            "thermostat": {"settings": {"compressorProtectionMinTemp": int(threshold * 10)}},
+        }
+        log_msg_action = "set outdoor temp threshold for aux"
+
+        try:
+            self._request_with_refresh(
+                "POST", ECOBEE_ENDPOINT_THERMOSTAT, log_msg_action, body=body
+            )
+        except (ExpiredTokenError, InvalidTokenError) as err:
+            raise err
+
     def _request_with_refresh(
         self,
         method: str,


### PR DESCRIPTION
Add the ability to change the outdoor temperature threshold which determines whether the ecobee calls for heat from the main heating source or the aux heating source.  Tested with local changes:

```
>>> e.get_thermostats()
True
>>> e.thermostats[0]['settings']['compressorProtectionMinTemp']
400
>>> e.set_aux_cutover_threshold(0, 45)
>>> e.get_thermostats()
True
>>> e.thermostats[0]['settings']['compressorProtectionMinTemp']
450
```
