### PR TITLE
Added function for updating climate sensors

### DIFF
--- a/pyecobee/__init__.py
+++ b/pyecobee/__init__.py
@@ -698,9 +698,10 @@ class Ecobee(object):
         programs: dict = self.thermostats[index]["program"]
         # Remove currentClimateRef key.
         programs.pop("currentClimateRef", None)
-        program_to_edit = next(
-            climate for climate in programs["climates"] if climate["name"] == climate_name)
 
+        for i, climate in enumerate(programs["climates"]):
+            if climate["name"] == climate_name:
+                climate_index = i
         """Update climate sensors with sensor_names list."""
         sensor_list = []
         for name in sensor_names:
@@ -710,7 +711,13 @@ class Ecobee(object):
                 if sensor["name"] == name:
                     sensor_list.append(
                         {"id": "{}:1".format(sensor["id"]), "name": name})
-        program_to_edit["sensors"] = sensor_list
+        try:
+            programs["climates"][climate_index]["sensors"] = sensor_list
+        except UnboundLocalError:
+            """This would occur if the climate_index was not assigned
+                because the climate name does not exist in the program climates."""
+            return
+
         """Updates Climate"""
         body = {
             "selection": {

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ SOFTWARE.
 """
 
 setup(name='python-ecobee-api',
-      version='0.2.15',
+      version='0.2.16',
       description='Python API for talking to Ecobee thermostats',
       url='https://github.com/nkgilley/python-ecobee-api',
       author='Nolan Gilley',


### PR DESCRIPTION
This might be an edge use case, but I have added the ability to update the sensors that are involved in the averaging of a climate. This is useful if you use a room occasionally, but when occupied, you want the climate sensor added to the used climate. This would also support removing the added sensor when no longer occupied.

I am sure the follow me functionality might be able to give similar results, but I like the level of control this would provide.

The plan would be for this functionality to be eventually added to Home Assistant as a service.

I will caveat this with I am not a programmer, so while the function works as intended, it may not be best practices. Please feel free to give feedback (looking to get better at Python).

Example function call.
```python
ecobee = Ecobee(config={ECOBEE_API_KEY: api_key,
                ECOBEE_REFRESH_TOKEN: refresh_token})
ecobee.get_thermostats()
# (thermostat index, climate program name, sensor list)
ecobee.update_climate_sensors(1, "Home", ["Master Bedroom", "Theater Room"])
```