### PR TITLE
Modified to allow for setting sensors based on IDs

### DIFF
--- a/pyecobee/errors.py
+++ b/pyecobee/errors.py
@@ -15,3 +15,6 @@ class ExpiredTokenError(EcobeeError):
 
 class InvalidTokenError(EcobeeError):
     """Raised when ecobee API returns a code indicating invalid credentials."""
+
+class InvalidSensorError(EcobeeError):
+    """Raised when remote sensor not present on thermostat."""


### PR DESCRIPTION
Modified the `update_climate_sensors` function to take either sensor names or ids. The need for IDs arises from home assistant needing to use something more unique than the name. 