### PR TITLE
Switch web auth to OAuth code flow + PKCE; add MFA challenge support

### DIFF
--- a/pyecobee/__init__.py
+++ b/pyecobee/__init__.py
@@ -1,5 +1,10 @@
 """ Python Code for Communication with the Ecobee Thermostat """
+import base64
 import datetime
+import hashlib
+import re
+import secrets
+from dataclasses import dataclass, field
 from typing import Optional
 
 import requests
@@ -30,8 +35,77 @@ from .const import (
     ECOBEE_USERNAME,
     ECOBEE_WEB_CLIENT_ID,
 )
-from .errors import ExpiredTokenError, InvalidSensorError, InvalidTokenError
+from .errors import (
+    EcobeeAuthFailedError,
+    EcobeeAuthMfaRequiredError,
+    EcobeeAuthUnknownError,
+    ExpiredTokenError,
+    InvalidSensorError,
+    InvalidTokenError,
+)
 from .util import config_from_file, convert_to_bool
+
+ECOBEE_REDIRECT_URI = "https://www.ecobee.com/home/authCallback"
+ECOBEE_AUDIENCE = "https://prod.ecobee.com/api/v1"
+ECOBEE_WEB_SCOPE = (
+    "openid offline_access smartWrite piiWrite piiRead smartRead deleteGrants"
+)
+ECOBEE_OAUTH_TOKEN_URL = f"{ECOBEE_AUTH_BASE_URL}/oauth/token"
+ECOBEE_MFA_OTP_CHALLENGE_PATH = "/u/mfa-otp-challenge"
+
+
+def _state_from_url(url: str) -> str:
+    """Extract the ``state`` query parameter from an Auth0 step URL."""
+    match = re.search(r"[?&]state=([^&]+)", url)
+    return match.group(1) if match else ""
+
+
+def _code_from_url(url: str) -> Optional[str]:
+    """Extract the authorization ``code`` query parameter from a callback URL."""
+    match = re.search(r"[?&]code=([^&]+)", url)
+    return match.group(1) if match else None
+
+
+def _final_url(resp: "requests.Response") -> str:
+    """Return the URL of the last hop, even when redirects were not followed.
+
+    If the response itself is a 3xx (no further follow), return the absolute
+    URL its ``Location`` header points to. Otherwise the ``resp.url`` is
+    already the landed URL.
+    """
+    if resp.is_redirect or resp.is_permanent_redirect:
+        return requests.compat.urljoin(resp.url, resp.headers.get("Location", ""))
+    return resp.url
+
+
+def _generate_pkce_pair() -> tuple[str, str]:
+    """Return ``(verifier, challenge)`` for OAuth2 PKCE.
+
+    The verifier is a URL-safe random string (RFC 7636 §4.1 requires 43-128
+    chars). The challenge is the base64url-encoded SHA-256 of the verifier
+    with padding stripped, suitable for ``code_challenge_method=S256``.
+    """
+    verifier = secrets.token_urlsafe(64)  # ~86 chars, within 43-128
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+    return verifier, challenge
+
+
+@dataclass
+class MfaChallenge:
+    """Opaque resumption state for an in-progress MFA-gated login.
+
+    Returned (via :class:`EcobeeAuthMfaRequiredError`) when ecobee Auth0
+    interrupts the login flow with an MFA challenge. Pass this back into
+    :meth:`Ecobee.submit_mfa_code` along with the user-entered code to
+    complete the login and obtain tokens.
+    """
+
+    challenge_url: str
+    state: str
+    mfa_type: str
+    cookies: dict = field(default_factory=dict)
+    code_verifier: str = ""
 
 
 class Ecobee(object):
@@ -175,110 +249,332 @@ class Ecobee(object):
             return False
 
     def request_tokens_web(self) -> bool:
-        # Keep all cookies in a session
+        """Log in via the ecobee web flow and obtain access + refresh tokens.
+
+        Uses OAuth2 authorization code flow with PKCE plus the ``offline_access``
+        scope so the response includes a refresh_token. Subsequent refreshes
+        go through :meth:`_refresh_with_refresh_token` without re-submitting
+        credentials.
+
+        Returns True on success. On any failure raises one of:
+
+        * :class:`EcobeeAuthMfaRequiredError` — ecobee Auth0 demanded an MFA
+          OTP. The error carries an :class:`MfaChallenge` resumption payload.
+          Pass it (plus the OTP code) to :meth:`submit_mfa_code` to finish.
+        * :class:`EcobeeAuthFailedError` — credentials were rejected.
+        * :class:`EcobeeAuthUnknownError` — HTTP/transport error or an
+          unexpected response shape from Auth0.
+        """
+        verifier, challenge = _generate_pkce_pair()
         session = requests.Session()
 
-        # Get the auth0 token and redirect to the identifier step of the login flow
-        auth0_url = f"{ECOBEE_AUTH_BASE_URL}/{ECOBEE_ENDPOINT_AUTH}"
-        resp = session.get(
-            auth0_url,
-            params={
-                "response_type": "token",
-                "response_mode": "form_post",
-                "client_id": ECOBEE_WEB_CLIENT_ID,
-                "redirect_uri": "https://www.ecobee.com/home/authCallback",
-                "audience": "https://prod.ecobee.com/api/v1",
-                "scope": "openid smartWrite piiWrite piiRead smartRead deleteGrants",
-            },
-        )
-        if "auth0" not in session.cookies:
-            _LOGGER.error(
-                f"Failed to obtain auth0 token from {auth0_url}: {resp.status_code} {resp.text}"
+        try:
+            resp = session.get(
+                f"{ECOBEE_AUTH_BASE_URL}/{ECOBEE_ENDPOINT_AUTH}",
+                params={
+                    "response_type": "code",
+                    "client_id": ECOBEE_WEB_CLIENT_ID,
+                    "redirect_uri": ECOBEE_REDIRECT_URI,
+                    "audience": ECOBEE_AUDIENCE,
+                    "scope": ECOBEE_WEB_SCOPE,
+                    "code_challenge": challenge,
+                    "code_challenge_method": "S256",
+                },
+                timeout=ECOBEE_DEFAULT_TIMEOUT,
             )
-            return False
-        else:
-            self.auth0_token = session.cookies["auth0"]
+            resp.raise_for_status()
+        except RequestException as err:
+            raise EcobeeAuthUnknownError(
+                f"Failed to start ecobee Auth0 login: {err}"
+            ) from err
 
-        # Submit the identifier/username and redirect to the password step
+        if "/u/login/identifier" not in resp.url:
+            raise EcobeeAuthUnknownError(
+                f"ecobee Auth0 did not redirect to the identifier step "
+                f"(landed at {resp.url}); login URL may have changed."
+            )
+
+        # Auth0 Universal Login: identifier-first, then password.
         identifier_url = resp.url
-        resp = session.post(
-            identifier_url,
-            data={
-                "username": self.username,
-            },
-        )
-        if resp.status_code != 200:
-            _LOGGER.error(f"Failed to submit username: {resp.status_code} {resp.text}")
-            return False
+        try:
+            resp = session.post(
+                identifier_url,
+                data={"state": _state_from_url(identifier_url), "username": self.username},
+                timeout=ECOBEE_DEFAULT_TIMEOUT,
+            )
+            resp.raise_for_status()
+        except RequestException as err:
+            raise EcobeeAuthUnknownError(f"Failed to submit username: {err}") from err
 
-        # Submit the password and get the access_token
+        if "/u/login/password" not in resp.url:
+            raise EcobeeAuthFailedError(
+                f"ecobee did not accept the username (landed at {resp.url})"
+            )
+
         password_url = resp.url
-        resp = session.post(
-            password_url,
-            data={
-                "username": self.username,
-                "password": self.password,
-            },
+        try:
+            # Don't follow the final redirect into authCallback — we want to
+            # read the ``code`` out of the Location header, not actually load
+            # the external ecobee.com page.
+            resp = session.post(
+                password_url,
+                data={
+                    "state": _state_from_url(password_url),
+                    "username": self.username,
+                    "password": self.password,
+                },
+                allow_redirects=False,
+                timeout=ECOBEE_DEFAULT_TIMEOUT,
+            )
+        except RequestException as err:
+            raise EcobeeAuthUnknownError(f"Failed to submit password: {err}") from err
+
+        # The password POST is expected to be a 302. Resolve the next URL by
+        # following Auth0's redirects (which may bounce through /authorize/resume
+        # and then either to /u/mfa-otp-challenge or to the authCallback).
+        landed_url = self._resolve_post_login_redirect(session, resp)
+        self._handle_post_password_response(landed_url, verifier, session)
+        return self._exchange_code_for_tokens(_code_from_url(landed_url), verifier)
+
+    def _resolve_post_login_redirect(
+        self, session: "requests.Session", resp: "requests.Response"
+    ) -> str:
+        """Walk Auth0's post-login redirect chain to its terminal URL.
+
+        After a successful password POST, Auth0 typically responds 302 →
+        /authorize/resume → 302 → either /u/mfa-otp-challenge (MFA) or
+        /home/authCallback?code=... (no MFA). We follow within the
+        auth.ecobee.com domain but stop at the moment we leave it, so the
+        external callback URL is read out of the Location header rather than
+        actually requested.
+        """
+        for _ in range(10):
+            if not (resp.is_redirect or resp.is_permanent_redirect):
+                return resp.url
+            next_url = requests.compat.urljoin(
+                resp.url, resp.headers.get("Location", "")
+            )
+            if not next_url.startswith(ECOBEE_AUTH_BASE_URL):
+                # About to leave auth.ecobee.com — return that URL without
+                # actually fetching it. This is where the authCallback lives.
+                return next_url
+            try:
+                resp = session.get(
+                    next_url,
+                    allow_redirects=False,
+                    timeout=ECOBEE_DEFAULT_TIMEOUT,
+                )
+            except RequestException as err:
+                raise EcobeeAuthUnknownError(
+                    f"Failed while following Auth0 redirect to {next_url}: {err}"
+                ) from err
+        raise EcobeeAuthUnknownError(
+            "Auth0 redirect chain exceeded 10 hops; aborting."
         )
-        if resp.status_code != 200:
-            _LOGGER.error(f"Failed to submit password: {resp.status_code} {resp.text}")
-            return False
 
-        if (
-            access_token := resp.text.split('name="access_token" value="')[1].split(
-                '"'
-            )[0]
-        ) is None:
-            _LOGGER.error("Failed to refresh bearer token: no access token in response")
-            return False
+    def submit_mfa_code(self, challenge: MfaChallenge, code: str) -> bool:
+        """Complete an MFA-gated login by submitting the user's OTP code.
 
-        self.access_token = access_token
+        ``challenge`` must be the payload carried by the
+        :class:`EcobeeAuthMfaRequiredError` raised earlier by
+        :meth:`request_tokens_web`. Returns True on success, raises
+        :class:`EcobeeAuthFailedError` for a rejected code, or
+        :class:`EcobeeAuthUnknownError` for any other problem.
+        """
+        session = requests.Session()
+        for name, value in challenge.cookies.items():
+            session.cookies.set(name, value)
 
-        if (
-            expires_in := resp.text.split('name="expires_in" value="')[1].split('"')[0]
-        ) is None:
-            _LOGGER.error("Failed to refresh bearer token: no expiration in response")
-            return False
+        try:
+            resp = session.post(
+                challenge.challenge_url,
+                data={"state": challenge.state, "code": code},
+                allow_redirects=False,
+                timeout=ECOBEE_DEFAULT_TIMEOUT,
+            )
+        except RequestException as err:
+            raise EcobeeAuthUnknownError(f"Failed to submit OTP code: {err}") from err
 
-        expires_at = datetime.datetime.now() + datetime.timedelta(
-            seconds=int(expires_in)
-        )
-        _LOGGER.debug(f"Access token expires at {expires_at}")
+        landed_url = self._resolve_post_login_redirect(session, resp)
+        # On a rejected OTP, Auth0 redirects back to the same challenge URL.
+        if ECOBEE_MFA_OTP_CHALLENGE_PATH in landed_url:
+            raise EcobeeAuthFailedError("The MFA code was not accepted by ecobee.")
+
+        code_value = _code_from_url(landed_url)
+        if not code_value:
+            raise EcobeeAuthUnknownError(
+                f"Unexpected response after MFA submission (landed at {landed_url})"
+            )
+        return self._exchange_code_for_tokens(code_value, challenge.code_verifier)
+
+    def _handle_post_password_response(
+        self,
+        landed_url: str,
+        verifier: str,
+        session: "requests.Session",
+    ) -> None:
+        """Branch on the URL Auth0 ultimately redirects to after the password POST.
+
+        Raises an appropriate ``EcobeeAuthError`` subclass unless ``landed_url``
+        contains an auth code (in which case the caller is expected to
+        exchange it).
+        """
+        if ECOBEE_MFA_OTP_CHALLENGE_PATH in landed_url:
+            raise EcobeeAuthMfaRequiredError(
+                MfaChallenge(
+                    challenge_url=landed_url,
+                    state=_state_from_url(landed_url),
+                    mfa_type="otp",
+                    cookies=session.cookies.get_dict(),
+                    code_verifier=verifier,
+                )
+            )
+        if "/u/mfa-" in landed_url:
+            # Other MFA challenge types (push/sms/email) — unsupported for now.
+            raise EcobeeAuthUnknownError(
+                f"ecobee account requires an MFA type that is not yet "
+                f"supported by this library (challenge URL: {landed_url}). "
+                f"TOTP via an authenticator app is supported."
+            )
+        if "/u/login/password" in landed_url:
+            raise EcobeeAuthFailedError(
+                "ecobee rejected the supplied password."
+            )
+        if _code_from_url(landed_url) is None:
+            raise EcobeeAuthUnknownError(
+                f"Unexpected response after login (landed at {landed_url})"
+            )
+
+    def _exchange_code_for_tokens(self, code: str, verifier: str) -> bool:
+        """Exchange an authorization code for access + refresh tokens."""
+        try:
+            resp = requests.post(
+                ECOBEE_OAUTH_TOKEN_URL,
+                data={
+                    "grant_type": "authorization_code",
+                    "code": code,
+                    "code_verifier": verifier,
+                    "client_id": ECOBEE_WEB_CLIENT_ID,
+                    "redirect_uri": ECOBEE_REDIRECT_URI,
+                },
+                timeout=ECOBEE_DEFAULT_TIMEOUT,
+            )
+            resp.raise_for_status()
+            payload = resp.json()
+        except (RequestException, ValueError) as err:
+            raise EcobeeAuthUnknownError(
+                f"Failed to exchange authorization code for tokens: {err}"
+            ) from err
+
+        try:
+            self.access_token = payload["access_token"]
+        except KeyError as err:
+            raise EcobeeAuthUnknownError(
+                f"Token exchange response missing access_token: {payload}"
+            ) from err
+        # refresh_token only present when offline_access was granted; absence
+        # makes the integration unusable past the first hour, so treat as fatal.
+        try:
+            self.refresh_token = payload["refresh_token"]
+        except KeyError as err:
+            raise EcobeeAuthUnknownError(
+                "Token exchange response did not include a refresh_token. "
+                "The Auth0 client_id may not have offline_access enabled."
+            ) from err
+
+        if "expires_in" in payload:
+            expires_at = datetime.datetime.now() + datetime.timedelta(
+                seconds=int(payload["expires_in"])
+            )
+            _LOGGER.debug(f"Access token expires at {expires_at}")
 
         self._write_config()
+        return True
 
+    def _refresh_with_refresh_token(self) -> bool:
+        """Refresh the access token via the OAuth2 refresh_token grant.
+
+        Uses ``auth.ecobee.com/oauth/token`` (the Auth0 endpoint used by the
+        web flow), not ``api.ecobee.com/token`` (the PIN-flow endpoint). Stores
+        any rotated refresh_token returned by Auth0.
+        """
+        try:
+            resp = requests.post(
+                ECOBEE_OAUTH_TOKEN_URL,
+                data={
+                    "grant_type": "refresh_token",
+                    "refresh_token": self.refresh_token,
+                    "client_id": ECOBEE_WEB_CLIENT_ID,
+                },
+                timeout=ECOBEE_DEFAULT_TIMEOUT,
+            )
+            resp.raise_for_status()
+            payload = resp.json()
+        except (RequestException, ValueError) as err:
+            raise EcobeeAuthUnknownError(
+                f"Failed to refresh ecobee tokens: {err}"
+            ) from err
+
+        try:
+            self.access_token = payload["access_token"]
+        except KeyError as err:
+            raise EcobeeAuthUnknownError(
+                f"Refresh response missing access_token: {payload}"
+            ) from err
+        # Auth0 may or may not rotate the refresh_token. Persist the new value
+        # if returned; keep the old one otherwise.
+        if "refresh_token" in payload:
+            self.refresh_token = payload["refresh_token"]
+
+        self._write_config()
         return True
 
     def refresh_tokens(self) -> bool:
+        """Refresh the access token.
+
+        Three paths, in priority order:
+
+        1. **PIN flow** (``api_key`` set): use the legacy ``api.ecobee.com/token``
+           endpoint with the stored refresh_token. PIN-flow refresh tokens are
+           tied to the developer API key and only work against that endpoint.
+        2. **Web flow with refresh_token**: use the OAuth2 refresh grant
+           against ``auth.ecobee.com/oauth/token``. No re-prompting for
+           credentials or MFA — this is the steady state after initial setup.
+        3. **Web flow with credentials but no refresh_token**: do a full web
+           login. Covers initial authentication and migrations from older
+           entries that pre-date refresh_token storage.
+        """
+        if self.api_key:
+            params = {
+                "grant_type": "refresh_token",
+                "refresh_token": self.refresh_token,
+                "client_id": self.api_key,
+            }
+            response = self._request(
+                "POST",
+                ECOBEE_ENDPOINT_TOKEN,
+                "refresh tokens",
+                params=params,
+                auth_request=True,
+            )
+            try:
+                self.access_token = response["access_token"]
+                self.refresh_token = response["refresh_token"]
+                self._write_config()
+                return True
+            except (KeyError, TypeError) as err:
+                _LOGGER.debug(f"Error refreshing tokens from ecobee: {err}")
+                return False
+
+        if self.refresh_token:
+            return self._refresh_with_refresh_token()
+
         if self.username and self.password:
             return self.request_tokens_web()
-        
-        """Refreshes ecobee API tokens."""
-        params = {
-            "grant_type": "refresh_token",
-            "refresh_token": self.refresh_token,
-            "client_id": self.api_key,
-        }
-        log_msg_action = "refresh tokens"
 
-        response = self._request(
-            "POST",
-            ECOBEE_ENDPOINT_TOKEN,
-            log_msg_action,
-            params=params,
-            auth_request=True,
+        raise EcobeeAuthUnknownError(
+            "No refresh_token, credentials, or API key available to refresh."
         )
-
-        try:
-            self.access_token = response["access_token"]
-            self.refresh_token = response["refresh_token"]
-            self._write_config()
-            _LOGGER.debug(f"Refreshed tokens from ecobee: access {self.access_token}, "
-                          f"refresh {self.refresh_token}")
-            return True
-        except (KeyError, TypeError) as err:
-            _LOGGER.debug(f"Error refreshing tokens from ecobee: {err}")
-            return False
 
     def get_thermostats(self) -> bool:
         """Gets a json-list of thermostats from ecobee and caches in self.thermostats."""

--- a/pyecobee/errors.py
+++ b/pyecobee/errors.py
@@ -18,3 +18,26 @@ class InvalidTokenError(EcobeeError):
 
 class InvalidSensorError(EcobeeError):
     """Raised when remote sensor not present on thermostat."""
+
+
+class EcobeeAuthFailedError(EcobeeError):
+    """Raised when ecobee Auth0 rejects the supplied credentials or OTP code."""
+
+    pass
+
+
+class EcobeeAuthUnknownError(EcobeeError):
+    """Raised when ecobee Auth0 returns an unexpected response shape."""
+
+    pass
+
+
+class EcobeeAuthMfaRequiredError(EcobeeError):
+    """Raised when ecobee Auth0 redirects to an MFA challenge during login.
+
+    Carries an :class:`~pyecobee.MfaChallenge` payload (in ``args[0]``) that
+    must be passed back into :meth:`Ecobee.submit_mfa_code` along with the
+    user-entered OTP code to resume the login flow.
+    """
+
+    pass

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,437 @@
+"""Tests for the ecobee Auth0 web login flow (auth code + PKCE + MFA).
+
+Each test uses ``requests_mock`` to stand in for Auth0. The shapes mocked here
+match what was captured against the live ecobee Auth0 tenant in
+``NOTES_auth_flow.md`` (see the repo root, not committed).
+"""
+
+from __future__ import annotations
+
+import re
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+import requests_mock as rm_module
+
+from pyecobee import (
+    Ecobee,
+    MfaChallenge,
+    _generate_pkce_pair,
+)
+from pyecobee.const import (
+    ECOBEE_PASSWORD,
+    ECOBEE_USERNAME,
+    ECOBEE_WEB_CLIENT_ID,
+)
+from pyecobee.errors import (
+    EcobeeAuthFailedError,
+    EcobeeAuthMfaRequiredError,
+    EcobeeAuthUnknownError,
+)
+
+
+AUTH_BASE = "https://auth.ecobee.com"
+TOKEN_URL = f"{AUTH_BASE}/oauth/token"
+CALLBACK_URL = "https://www.ecobee.com/home/authCallback"
+
+
+def _make_ecobee() -> Ecobee:
+    """Build an Ecobee instance with username/password set, no tokens."""
+    return Ecobee(
+        config={
+            ECOBEE_USERNAME: "user@example.com",
+            ECOBEE_PASSWORD: "hunter2",
+        }
+    )
+
+
+def _register_initial_get(m: rm_module.Mocker, state: str = "STATE_1") -> None:
+    """Wire up the GET /authorize → 302 → /u/login/identifier hop.
+
+    Mimics Auth0 by setting the ``auth0`` session cookie on the landed page
+    (the library refuses to continue without it). requests_mock's ``cookies=``
+    populates the session cookie jar through ``extract_cookies_to_jar``.
+    """
+    m.get(
+        f"{AUTH_BASE}/authorize",
+        status_code=302,
+        headers={"Location": f"{AUTH_BASE}/u/login/identifier?state={state}"},
+    )
+    m.get(
+        f"{AUTH_BASE}/u/login/identifier",
+        status_code=200,
+        text="<html>identifier form</html>",
+        cookies={"auth0": "sess-cookie"},
+    )
+
+
+def _register_identifier_post(
+    m: rm_module.Mocker, state: str = "STATE_1"
+) -> None:
+    """Wire up POST /u/login/identifier → 302 → /u/login/password."""
+    m.post(
+        f"{AUTH_BASE}/u/login/identifier",
+        status_code=302,
+        headers={"Location": f"{AUTH_BASE}/u/login/password?state={state}"},
+    )
+    m.get(
+        f"{AUTH_BASE}/u/login/password",
+        status_code=200,
+        text="<html>password form</html>",
+    )
+
+
+def test_pkce_pair_shape() -> None:
+    """PKCE verifier length must be within RFC 7636 bounds; challenge derives from it."""
+    import base64
+    import hashlib
+
+    verifier, challenge = _generate_pkce_pair()
+    assert 43 <= len(verifier) <= 128
+    expected = (
+        base64.urlsafe_b64encode(hashlib.sha256(verifier.encode("ascii")).digest())
+        .rstrip(b"=")
+        .decode("ascii")
+    )
+    assert challenge == expected
+
+
+def test_request_tokens_web_uses_auth_code_flow_params(
+    requests_mock: rm_module.Mocker,
+) -> None:
+    """The initial /authorize call must request code flow + PKCE + offline_access."""
+    _register_initial_get(requests_mock)
+    _register_identifier_post(requests_mock)
+    # Password POST lands at the callback with an auth code (no MFA path).
+    requests_mock.post(
+        f"{AUTH_BASE}/u/login/password",
+        status_code=302,
+        headers={"Location": f"{CALLBACK_URL}?code=AUTH_CODE_XYZ"},
+    )
+    requests_mock.post(
+        TOKEN_URL,
+        status_code=200,
+        json={
+            "access_token": "AT-1",
+            "refresh_token": "RT-1",
+            "expires_in": 3600,
+            "token_type": "Bearer",
+        },
+    )
+
+    ecobee = _make_ecobee()
+    assert ecobee.request_tokens_web() is True
+    assert ecobee.access_token == "AT-1"
+    assert ecobee.refresh_token == "RT-1"
+
+    # Inspect the first call (the /authorize GET) for required OAuth2 params.
+    authorize_call = requests_mock.request_history[0]
+    qs = parse_qs(urlparse(authorize_call.url).query)
+    assert qs["response_type"] == ["code"]
+    assert qs["client_id"] == [ECOBEE_WEB_CLIENT_ID]
+    assert "offline_access" in qs["scope"][0]
+    assert qs["code_challenge_method"] == ["S256"]
+    assert qs["code_challenge"][0]  # non-empty challenge present
+
+
+def test_request_tokens_web_exchanges_code_with_verifier(
+    requests_mock: rm_module.Mocker,
+) -> None:
+    """The /oauth/token POST must include the original PKCE verifier and the code."""
+    _register_initial_get(requests_mock)
+    _register_identifier_post(requests_mock)
+    requests_mock.post(
+        f"{AUTH_BASE}/u/login/password",
+        status_code=302,
+        headers={"Location": f"{CALLBACK_URL}?code=AUTHCODE_42"},
+    )
+    requests_mock.post(
+        TOKEN_URL,
+        status_code=200,
+        json={
+            "access_token": "AT-token",
+            "refresh_token": "RT-token",
+            "expires_in": 3600,
+        },
+    )
+
+    ecobee = _make_ecobee()
+    ecobee.request_tokens_web()
+
+    token_call = next(
+        c for c in requests_mock.request_history if c.url == TOKEN_URL
+    )
+    body = parse_qs(token_call.text)
+    assert body["grant_type"] == ["authorization_code"]
+    assert body["code"] == ["AUTHCODE_42"]
+    assert body["client_id"] == [ECOBEE_WEB_CLIENT_ID]
+    assert body["code_verifier"][0]  # the PKCE verifier round-trips
+
+
+def test_request_tokens_web_wrong_password_raises_failed(
+    requests_mock: rm_module.Mocker,
+) -> None:
+    """When Auth0 rejects the password it re-renders the password page; map to AuthFailed."""
+    _register_initial_get(requests_mock)
+    _register_identifier_post(requests_mock)
+    # Auth0 behavior on bad password: redirect back to /u/login/password.
+    requests_mock.post(
+        f"{AUTH_BASE}/u/login/password",
+        status_code=302,
+        headers={"Location": f"{AUTH_BASE}/u/login/password?state=STATE_1&error=1"},
+    )
+
+    ecobee = _make_ecobee()
+    with pytest.raises(EcobeeAuthFailedError):
+        ecobee.request_tokens_web()
+
+
+def test_request_tokens_web_mfa_required_raises_with_challenge(
+    requests_mock: rm_module.Mocker,
+) -> None:
+    """MFA-enabled accounts get a typed exception carrying the resumption state."""
+    _register_initial_get(requests_mock)
+    _register_identifier_post(requests_mock)
+    # Auth0 with MFA: password POST 302s into the OTP challenge.
+    requests_mock.post(
+        f"{AUTH_BASE}/u/login/password",
+        status_code=302,
+        headers={
+            "Location": f"{AUTH_BASE}/u/mfa-otp-challenge?state=MFA_STATE_9"
+        },
+    )
+    requests_mock.get(
+        f"{AUTH_BASE}/u/mfa-otp-challenge",
+        status_code=200,
+        text="<html>OTP form</html>",
+    )
+
+    ecobee = _make_ecobee()
+    with pytest.raises(EcobeeAuthMfaRequiredError) as exc_info:
+        ecobee.request_tokens_web()
+    challenge = exc_info.value.args[0]
+    assert isinstance(challenge, MfaChallenge)
+    assert challenge.mfa_type == "otp"
+    assert challenge.state == "MFA_STATE_9"
+    assert "mfa-otp-challenge" in challenge.challenge_url
+    assert challenge.code_verifier  # PKCE verifier preserved for resumption
+
+
+def test_request_tokens_web_unsupported_mfa_type_raises_unknown(
+    requests_mock: rm_module.Mocker,
+) -> None:
+    """SMS/push/email challenge URLs aren't supported in v1; surface clearly."""
+    _register_initial_get(requests_mock)
+    _register_identifier_post(requests_mock)
+    requests_mock.post(
+        f"{AUTH_BASE}/u/login/password",
+        status_code=302,
+        headers={
+            "Location": f"{AUTH_BASE}/u/mfa-sms-challenge?state=SMS_STATE"
+        },
+    )
+    requests_mock.get(
+        f"{AUTH_BASE}/u/mfa-sms-challenge",
+        status_code=200,
+        text="<html>SMS form</html>",
+    )
+
+    ecobee = _make_ecobee()
+    with pytest.raises(EcobeeAuthUnknownError, match="not yet supported"):
+        ecobee.request_tokens_web()
+
+
+def test_request_tokens_web_unexpected_initial_landing_raises_unknown(
+    requests_mock: rm_module.Mocker,
+) -> None:
+    """If /authorize redirects somewhere other than /u/login/identifier, fail clearly."""
+    requests_mock.get(
+        f"{AUTH_BASE}/authorize",
+        status_code=302,
+        headers={"Location": f"{AUTH_BASE}/some/other/path"},
+    )
+    requests_mock.get(
+        f"{AUTH_BASE}/some/other/path",
+        status_code=200,
+        text="<html></html>",
+    )
+
+    ecobee = _make_ecobee()
+    with pytest.raises(EcobeeAuthUnknownError, match="did not redirect"):
+        ecobee.request_tokens_web()
+
+
+def test_token_exchange_missing_refresh_token_raises_unknown(
+    requests_mock: rm_module.Mocker,
+) -> None:
+    """If Auth0 issues an access_token but no refresh_token, fail fast."""
+    _register_initial_get(requests_mock)
+    _register_identifier_post(requests_mock)
+    requests_mock.post(
+        f"{AUTH_BASE}/u/login/password",
+        status_code=302,
+        headers={"Location": f"{CALLBACK_URL}?code=CODE_X"},
+    )
+    requests_mock.post(
+        TOKEN_URL,
+        status_code=200,
+        json={"access_token": "AT-1", "expires_in": 3600},  # no refresh_token
+    )
+
+    ecobee = _make_ecobee()
+    with pytest.raises(EcobeeAuthUnknownError, match="refresh_token"):
+        ecobee.request_tokens_web()
+
+
+def test_submit_mfa_code_success(requests_mock: rm_module.Mocker) -> None:
+    """Submitting a valid OTP completes the login and stores both tokens."""
+    challenge_url = f"{AUTH_BASE}/u/mfa-otp-challenge?state=MFA_STATE"
+    # OTP POST: 302 to the callback with an auth code.
+    requests_mock.post(
+        challenge_url,
+        status_code=302,
+        headers={"Location": f"{CALLBACK_URL}?code=POST_MFA_CODE"},
+    )
+    requests_mock.post(
+        TOKEN_URL,
+        status_code=200,
+        json={
+            "access_token": "AT-mfa",
+            "refresh_token": "RT-mfa",
+            "expires_in": 3600,
+        },
+    )
+
+    challenge = MfaChallenge(
+        challenge_url=challenge_url,
+        state="MFA_STATE",
+        mfa_type="otp",
+        cookies={"auth0": "sess"},
+        code_verifier="VERIFIER_VALUE",
+    )
+    ecobee = _make_ecobee()
+    assert ecobee.submit_mfa_code(challenge, "123456") is True
+    assert ecobee.access_token == "AT-mfa"
+    assert ecobee.refresh_token == "RT-mfa"
+
+    # Confirm the OTP POST sent state + code, and the token exchange reused
+    # the stored verifier (not a fresh one).
+    otp_call = next(
+        c
+        for c in requests_mock.request_history
+        if "mfa-otp-challenge" in c.url and c.method == "POST"
+    )
+    body = parse_qs(otp_call.text)
+    assert body["state"] == ["MFA_STATE"]
+    assert body["code"] == ["123456"]
+
+    token_call = next(c for c in requests_mock.request_history if c.url == TOKEN_URL)
+    token_body = parse_qs(token_call.text)
+    assert token_body["code_verifier"] == ["VERIFIER_VALUE"]
+
+
+def test_submit_mfa_code_wrong_code_raises_failed(
+    requests_mock: rm_module.Mocker,
+) -> None:
+    """Auth0 re-renders the challenge page on a bad OTP; map to AuthFailed."""
+    challenge_url = f"{AUTH_BASE}/u/mfa-otp-challenge?state=MFA_STATE"
+    requests_mock.post(
+        challenge_url,
+        status_code=302,
+        headers={
+            "Location": f"{AUTH_BASE}/u/mfa-otp-challenge?state=MFA_STATE&error=1"
+        },
+    )
+    requests_mock.get(
+        f"{AUTH_BASE}/u/mfa-otp-challenge",
+        status_code=200,
+        text="<html>retry</html>",
+    )
+
+    challenge = MfaChallenge(
+        challenge_url=challenge_url,
+        state="MFA_STATE",
+        mfa_type="otp",
+        code_verifier="V",
+    )
+    ecobee = _make_ecobee()
+    with pytest.raises(EcobeeAuthFailedError, match="not accepted"):
+        ecobee.submit_mfa_code(challenge, "000000")
+
+
+def test_refresh_tokens_prefers_refresh_grant_when_token_present(
+    requests_mock: rm_module.Mocker,
+) -> None:
+    """With a refresh_token set, refresh_tokens must not re-do the web login."""
+    requests_mock.post(
+        TOKEN_URL,
+        status_code=200,
+        json={"access_token": "AT-2", "refresh_token": "RT-2", "expires_in": 3600},
+    )
+
+    ecobee = _make_ecobee()
+    ecobee.refresh_token = "RT-1"  # pretend we have one from a prior login
+    assert ecobee.refresh_tokens() is True
+    assert ecobee.access_token == "AT-2"
+    assert ecobee.refresh_token == "RT-2"
+
+    # Only one HTTP call: the refresh grant POST. No /authorize GET, no
+    # /u/login/* hops.
+    assert len(requests_mock.request_history) == 1
+    only_call = requests_mock.request_history[0]
+    assert only_call.url == TOKEN_URL
+    body = parse_qs(only_call.text)
+    assert body["grant_type"] == ["refresh_token"]
+    assert body["refresh_token"] == ["RT-1"]
+
+
+def test_refresh_tokens_keeps_old_refresh_token_when_not_rotated(
+    requests_mock: rm_module.Mocker,
+) -> None:
+    """Auth0 may omit refresh_token from the refresh response (no rotation)."""
+    requests_mock.post(
+        TOKEN_URL,
+        status_code=200,
+        json={"access_token": "AT-new", "expires_in": 3600},  # no refresh_token
+    )
+
+    ecobee = _make_ecobee()
+    ecobee.refresh_token = "RT-original"
+    assert ecobee.refresh_tokens() is True
+    assert ecobee.access_token == "AT-new"
+    assert ecobee.refresh_token == "RT-original"
+
+
+def test_refresh_tokens_no_credentials_raises(
+    requests_mock: rm_module.Mocker,
+) -> None:
+    """An Ecobee with no refresh_token, no credentials, no api_key has nothing to do."""
+    ecobee = Ecobee(config={})
+    with pytest.raises(EcobeeAuthUnknownError, match="No refresh_token"):
+        ecobee.refresh_tokens()
+
+
+def test_refresh_tokens_falls_back_to_web_login_for_legacy_entries(
+    requests_mock: rm_module.Mocker,
+) -> None:
+    """A legacy entry with username+password but no refresh_token re-logs in.
+
+    This is the migration path: the first refresh after upgrading does a fresh
+    web login (which now uses auth code flow and obtains a refresh_token).
+    """
+    _register_initial_get(requests_mock)
+    _register_identifier_post(requests_mock)
+    requests_mock.post(
+        f"{AUTH_BASE}/u/login/password",
+        status_code=302,
+        headers={"Location": f"{CALLBACK_URL}?code=MIGRATION_CODE"},
+    )
+    requests_mock.post(
+        TOKEN_URL,
+        status_code=200,
+        json={"access_token": "AT-m", "refresh_token": "RT-m", "expires_in": 3600},
+    )
+
+    ecobee = _make_ecobee()  # no refresh_token
+    assert ecobee.refresh_tokens() is True
+    assert ecobee.refresh_token == "RT-m"


### PR DESCRIPTION
## Summary

This PR rewrites the username/password web authentication path to fix two
defects that together make the feature broken for any account with MFA
enabled, and broken-by-design even without MFA:

1. **No refresh tokens.** `request_tokens_web()` previously used OAuth2
   implicit flow (`response_type=token`, no `offline_access` scope). Since
   implicit flow cannot issue a `refresh_token`, `refresh_tokens()` was
   re-running the full username/password web login on every refresh (every
   hour, plus on every `ExpiredTokenError`). This sends credentials over the
   wire every refresh and makes MFA support intractable (you'd be prompted for
   an OTP code every hour).
2. **No MFA challenge handling.** When Auth0 responded with an MFA challenge
   page instead of the success form, the existing code blindly scraped for
   `name="access_token" value="..."` and raised an unhandled `IndexError`.
   No detection, no recovery, no way to submit a code. This is the immediate
   cause of [home-assistant/core#170439](https://github.com/home-assistant/core/issues/170439).

## Changes

- **Switch web auth from OAuth2 implicit flow to authorization code flow with
  PKCE.** Adds `code_challenge`/`code_challenge_method=S256` and the
  `offline_access` scope so the `/oauth/token` exchange returns a real
  `refresh_token`.
- **Rewrite `refresh_tokens()`** to prefer the OAuth2 refresh_token grant
  (POST to `https://auth.ecobee.com/oauth/token`) when a `refresh_token` is
  available. Falls back to the full web login only when no `refresh_token`
  exists yet (initial auth or migration from older entries). The legacy PIN +
  API key path is preserved unchanged.
- **Detect Auth0 MFA challenges** after the password POST. When the response
  lands at `/u/mfa-otp-challenge`, raise the new
  `EcobeeAuthMfaRequiredError` carrying an opaque `MfaChallenge` payload.
  Callers pass that payload (plus the user-entered OTP) back into the new
  `submit_mfa_code()` method to complete the login.
- **Replace fragile `.split[...][1]` HTML scrapes** with `re.search()`-based
  extraction that returns `None` on no match and raises typed exceptions on
  unexpected responses.
- **Add typed exceptions** to `pyecobee.errors`:
  `EcobeeAuthFailedError`, `EcobeeAuthMfaRequiredError`,
  `EcobeeAuthUnknownError` — all subclasses of the existing `EcobeeError`.
- **Add unit tests** at `tests/test_auth.py` (14 tests, requests-mock-based)
  covering: PKCE shape, OAuth params on `/authorize`, code+verifier on
  `/oauth/token`, wrong-password failure, MFA-required raising a typed
  exception with intact `MfaChallenge`, unsupported MFA types, missing
  `refresh_token` in response, OTP success + wrong-code paths, and
  refresh_token grant preferred over web login.

## Behavior change

`request_tokens_web()` and `refresh_tokens()` now **raise typed exceptions**
on failure paths in addition to (or instead of) returning `False`. The happy
path still returns `True`. Existing callers that ignored the return value will
see exceptions propagate; this is intentional — the previous silent-`False`
behavior is what allowed home-assistant/core#170439 to surface as 'Unknown
error occurred' instead of an actionable message.

The PIN flow (`request_pin`/`request_tokens` with an API key) is untouched.

## Test plan

- [x] Unit tests added at `tests/test_auth.py` — 14 tests, all pass via
      `pytest tests/test_auth.py`. The repo had no test suite before this PR;
      a minimal `tests/__init__.py` is included.
- [x] Manual end-to-end against a real ecobee account with MFA (TOTP)
      enabled: initial login + MFA challenge + token exchange succeeded;
      a subsequent `refresh_tokens()` call used the refresh grant alone with
      no MFA re-prompt. Both `access_token` and `refresh_token` were issued.
- [x] Manual end-to-end via Home Assistant: ecobee integration adds via the
      MFA flow, restarts cleanly, refreshes tokens in <500ms without
      re-prompting. Thermostat data fetched, climate/sensor/switch/etc.
      entities all created. Companion HA core PR to follow this one.

## Out of scope (deferred)

- SMS / push / email MFA challenge types. Auth0 routes these to
  `/u/mfa-{sms,push,email}-challenge` endpoints not exercised by the captured
  TOTP flow. The new code detects those URLs and raises
  `EcobeeAuthUnknownError` with a clear message rather than crashing.
- Reauth flow on the HA side — separate scope; the refresh_token grant should
  keep entries valid indefinitely once set up.